### PR TITLE
필터 아이템 클릭 시 필터 결과가 렌더링되지 않는 문제 해결

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,27 +7,23 @@ import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
 import useModal from '@/hooks/useModal';
 import FilterMenuModal from '@/components/home/FilterMenuModal';
+import { useSearchParams } from 'next/navigation';
 
-interface HomePageProps {
-  searchParams: {
-    note: string;
-    brand: string;
-  };
-}
-
-function Home({ searchParams }: HomePageProps) {
+function Home() {
+  const searchParams = useSearchParams();
   const [perfumeListData, setPerfumeListData] = useState<Perfume[]>();
   const [noteList, setNoteList] = useState<NoteList[]>([]);
   const [brandList, setBrandList] = useState<BrandList[]>([]);
   const filterModal = useModal('filterModal');
 
   const fetchPerfumeList = async () => {
+    const note = searchParams.get('note');
+    const brand = searchParams.get('brand');
+
     const perfumeListData =
-      searchParams.note || searchParams.brand
+      note || brand
         ? await fetch(
-            `/api/filteredPerfumeList?notes=${searchParams.note ? searchParams.note.split('|') : []}&brands=${
-              searchParams.brand ? searchParams.brand.split('|') : []
-            }`,
+            `/api/filteredPerfumeList?notes=${note ? note.split('|') : []}&brands=${brand ? brand.split('|') : []}`,
             {
               cache: 'no-store',
             }
@@ -36,8 +32,6 @@ function Home({ searchParams }: HomePageProps) {
 
     setPerfumeListData(perfumeListData);
   };
-
-  console.log(searchParams);
 
   useEffect(() => {
     Promise.all([
@@ -52,7 +46,7 @@ function Home({ searchParams }: HomePageProps) {
 
   useEffect(() => {
     fetchPerfumeList();
-  }, [searchParams.note, searchParams.brand]);
+  }, [searchParams.get('note'), searchParams.get('brand')]);
 
   if (!perfumeListData || !noteList.length || !brandList.length) return <div>Loading...</div>;
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,6 +37,8 @@ function Home({ searchParams }: HomePageProps) {
     setPerfumeListData(perfumeListData);
   };
 
+  console.log(searchParams);
+
   useEffect(() => {
     Promise.all([
       fetch('/api/noteList', { next: { revalidate: 3600 } }),

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,7 +50,7 @@ function Home({ searchParams }: HomePageProps) {
 
   useEffect(() => {
     fetchPerfumeList();
-  }, [searchParams]);
+  }, [searchParams.note, searchParams.brand]);
 
   if (!perfumeListData || !noteList.length || !brandList.length) return <div>Loading...</div>;
   return (


### PR DESCRIPTION
- page의 props로 searchParams를 전달할 경우 로컬 환경에서는 동작하지만 배포 환경에서는 동작하지 않는 이슈가 있는 것으로 확인
  (참고: https://github.com/vercel/next.js/issues/43077)
- useSearchParams hook을 적용하여 해결